### PR TITLE
major version bump

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,8 @@ util.inherits(Transaction, EventEmitter);
  */
 Transaction.prototype.query = function(){
   var self = this;
-  var query = pgClient.prototype.query.apply(this.client, arguments);
+
+  var query = this.client.query.apply(this.client, arguments);
 
   var callback = query.callback;
 
@@ -30,15 +31,6 @@ Transaction.prototype.query = function(){
       self.emit('error', err);
     });
   }
-  /*
-  query.callback = function(err){
-    if(err) self.client.resumeDrain();
-    if (callback != null) return callback.apply(null, arguments);
-    if(err) {
-      self.emit('error', err);
-    }
-  }
-  */
   return query;
 };
 
@@ -47,7 +39,6 @@ Transaction.prototype.query = function(){
  * @param  {Function} callback
  */
 Transaction.prototype.begin = function(callback){
-  this.client.pauseDrain();
   this.query('BEGIN', callback);
 };
 
@@ -77,7 +68,6 @@ Transaction.prototype.commit = function(callback){
   var self = this;
 
   this.query('COMMIT', function(err){
-    self.client.resumeDrain();
     if (callback) return callback(err);
     if (err) return self.emit('error', err);
   });
@@ -99,7 +89,6 @@ Transaction.prototype.rollback = function(savepoint, callback){
   var query = (savepoint != null) ? 'ROLLBACK TO SAVEPOINT ' + savepoint : 'ROLLBACK';
 
   this.query(query, function(err){
-    if (savepoint == null) self.client.resumeDrain();
     if (callback) return callback(err);
     if (err) return self.emit('error', err);
   });
@@ -113,7 +102,6 @@ Transaction.prototype.abort = function(callback) {
   var self = this;
 
   this.query('ABORT TRANSACTION', function(err){
-    self.client.resumeDrain();
     if (callback) return callback(err);
     if (err) return self.emit('error', err);
   });

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "pg-transaction",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "simplify executing transactions with node-postgres",
   "main": "index.js",
   "directories": {
     "test": "test"
   },
-  "dependencies": {
-    "pg": "0.10.x"
+  "peerDependencies": {
+    "pg": "1.x"
   },
   "devDependencies": {
     "mocha": "1.7.x",

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,8 @@ describe('transaction', function(){
     this.client.query("CREATE TEMP TABLE beatles(name varchar(10), height integer, birthday timestamptz, large bigint)");
   });
 
-  afterEach(function(){
+  afterEach(function(done){
+    this.client.on('end', done);
     this.client.end();
   });
 
@@ -80,9 +81,8 @@ describe('transaction', function(){
     tx.rollback('test', function(err){
       should.exist(err);
       err.code.should.equal('3B001');
-      done();
     });
-    tx.commit();
+    tx.commit(done);
   });
 
   it('error in transaction', function(done){

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,7 @@ var
 , async = require('async')
 , should = require('should')
 , Transaction = require('../')
+, assert = require('assert')
 ;
 
 var
@@ -128,7 +129,15 @@ describe('transaction', function(){
             if (err) {
               tx.rollback('savepoint1', function(err){
                 if (err) throw err;
-                tx.query("INSERT INTO beatles(name, height, birthday) values($1, $2, $3)", ['John', 68, new Date(1944, 10, 13)], function(err){
+                tx.query("INSERT INTO beatles(name, height, birthday) values($1, $2, $3) RETURNING *", ['John', 68, new Date(1944, 10, 13)], function(err, result){
+                  assert.ifError(err);
+                  assert(result, "should have a result");
+                  assert(result.rows, "result should have rows");
+                  result.rows.length.should.eql(1);
+                  var john = result.rows[0];
+                  john.name.should.eql('John');
+                  john.height.should.eql(68);
+                  john.birthday.getFullYear().should.eql(1944);
                   tx.commit(function(err){
                     if (err) throw err;
                     checkDone();


### PR DESCRIPTION
Bump major version as this breaks backwards compatibility.

I changed the code to support pg @ v1.0 and onward.  Made it a peerDependency so it wont install unless you have a proper version of pg installed.  This means removing all pauseDrain() and resumeDrain() stuff.  If you create a transaction object & pass it in a client, you are responsible for returning that client to the pool after the transaction is finished or disconnecting the client if the client is not pooled, etc...

I think what would be cool is to be able to pass in a pool instead of a client & the transaction will automatically check out a client from the pool and return the client to the pool upon `abort`, `commit`, or `rollback`

I changed the tests slightly to be more 'sync' by only exiting the afterEach when the client finished disconnecting.
