### PR TITLE
out of date with node-postgres

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "peerDependencies": {
-    "pg": "2.x"
+    "pg": "*"
   },
   "devDependencies": {
     "pg": "2.x",


### PR DESCRIPTION
node-postgres has been bumped up to version 3.x because of some non-backwards compatible changes, see [here](https://github.com/brianc/node-postgres/blob/a29affe17e5ec1eba4844afa231eeb5ffefb0a61/NEWS.md)

I don't think that these will impact on this project, so can the [package.json peer](https://github.com/goodybag/node-pg-transaction/blob/master/package.json#L10) be updated to "3.x" ?
